### PR TITLE
Added request drain in canUpload middleware

### DIFF
--- a/src/interface/middleware/canUpload.js
+++ b/src/interface/middleware/canUpload.js
@@ -30,9 +30,15 @@ async function canUpload(req, res, next) {
     const message = `Storage for ${contractAddress} is full, please either claim more storage or contact us on twitter @fileverse`;
     // ErrorHandler.throwError({ code: statusCode, message, req });
     reporter.reportError(message).catch(console.log);
-    res.status(statusCode).json({ message })
-    res.end();
-    req.connection.destroy();
+
+    if (req.readable) {
+      req.resume();
+      req.on('end', () => {
+        res.status(statusCode).json({ error: message });
+      });
+    } else {
+      res.status(statusCode).json({ error: message });
+    }
     return;
   }
 


### PR DESCRIPTION
- **upload middleware not throwing error on storagelimit breach**
- **added .end()**
- **res.end() added separately**
- **request connection destroy added**
- **testing draining of request**
